### PR TITLE
add a helpful error message when job leaves the system

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -110,8 +110,6 @@ $(document).ready( function() {
             row.child( format(row.data()) ).show();
             tr.addClass('shown');
             $.getJSON(APP_PATH + '/json?pbsid='+row.data().pbsid+'&host='+row.data().cluster , function(data) {
-              console.log(row.data());
-              console.log(data);
               $( "#" + EncodeCSS(row.data().pbsid)).hide().html(display_enhanced_job_data(data)).fadeIn(250);
             });
         }

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -110,6 +110,7 @@ $(document).ready( function() {
             row.child( format(row.data()) ).show();
             tr.addClass('shown');
             $.getJSON(APP_PATH + '/json?pbsid='+row.data().pbsid+'&host='+row.data().cluster , function(data) {
+              console.log(row.data());
               console.log(data);
               $( "#" + EncodeCSS(row.data().pbsid)).hide().html(display_enhanced_job_data(data)).fadeIn(250);
             });
@@ -176,8 +177,9 @@ function display_node_rows( d ) {
 function display_enhanced_job_data( d ) {
 
     if (is_defined(d.error)) {
-        return      '<div><tr><td>'+ d.error +'</td></tr></div>';
+        return      '<div><tr><td><div class="alert alert-warning">No job details because job has already left the queue. </div></td></tr></div>';
     } else {
+
         return      '<div>' +
                     '   <tr>' +
                     '        <td>' +

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -175,7 +175,7 @@ function display_node_rows( d ) {
 function display_enhanced_job_data( d ) {
 
     if (is_defined(d.error)) {
-        return      '<div><tr><td><div class="alert alert-warning">No job details because job has already left the queue. </div></td></tr></div>';
+        return      '<div><tr><td><div class="alert alert-warning">' + d.error + '</div></td></tr></div>';
     } else {
 
         return      '<div>' +

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -62,7 +62,7 @@ class PagesController < ApplicationController
       Jobstatusdata.new({name: name, attribs: attribs}, cluster.id, true)
 
     rescue
-      "[{\"name\":\"#{pbsid}\",\"error\":\"Job data expired or invalid.\"}]"
+      { name: pbsid, error: "INVALID" }
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -61,8 +61,10 @@ class PagesController < ApplicationController
       name, attribs = b.get_job(pbsid).first
       Jobstatusdata.new({name: name, attribs: attribs}, cluster.id, true)
 
-    rescue
-      { name: pbsid, error: "INVALID" }
+    rescue PBS::UnkjobidError
+      { name: pbsid, error: "No job details because job has already left the queue." , status: "C" }
+    rescue => e
+      { name: pbsid, error: "No job details available." }
     end
   end
 


### PR DESCRIPTION
This is a partial solution to https://github.com/OSC/osc-jobstatus/issues/69

Adds a message that says "No job details because job has already left the queue."

A bug was causing it not to show a message previously, this cleans it up and wraps it in a bootstrap warning alert.

Updating the row status still needs to be done and will take some DataTables magic.

