### PR TITLE
handle case when OodAppkit.clusters is nil

### DIFF
--- a/config/initializers/ood_appkit.rb
+++ b/config/initializers/ood_appkit.rb
@@ -1,7 +1,12 @@
 # config/initializers/ood_appkit.rb
 
-OODClusters = OodAppkit.clusters.select do |c|
-  c.valid? &&
+begin
+  OODClusters = OodAppkit.clusters.select do |c|
+    c.valid? &&
     c.resource_mgr_server? &&
     c.resource_mgr_server.is_a?(OodCluster::Servers::Torque)
-end.each_with_object({}) { |c, h| h[c.id] = c }
+  end.each_with_object({}) { |c, h| h[c.id] = c }
+rescue
+  # If OodAppkit.clusters is nil
+  OODClusters = {}
+end


### PR DESCRIPTION
In case a call to `OodAppkit.clusters` is invalid (missing cluster config?) the initializer sets the OODClusters var to an empty hash to prevent app crashing.

This may be unnecessary if OodAppkit already returns an empty hash in response to an `OodAppkit.clusters` call when the cluster config is missing.