### PR TITLE
Use metadata title instead of titleized id

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -122,7 +122,7 @@ $(document).ready( function() {
                 "autoWidth":        true
             },
             {
-                data:               "cluster",
+                data:               "cluster_title",
                 className:          "small",
                 "render":           function(data) {
                                         return data.charAt(0).toUpperCase() + data.substr(1);

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -124,9 +124,6 @@ $(document).ready( function() {
             {
                 data:               "cluster_title",
                 className:          "small",
-                "render":           function(data) {
-                                        return data.charAt(0).toUpperCase() + data.substr(1);
-                                    },
                 "autoWidth":        true
             }
         ]

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -59,7 +59,7 @@ class PagesController < ApplicationController
       data = OODClusters[cluster].job_adapter.info(jobid)
 
       raise OodCore::JobAdapterError if data.native.nil?
-      Jobstatusdata.new(data, cluster.id.to_s, true)
+      Jobstatusdata.new(data, cluster, true)
 
     rescue OodCore::JobAdapterError
       { name: jobid, error: "No job details because job has already left the queue." , status: "completed" }
@@ -108,7 +108,7 @@ class PagesController < ApplicationController
         # for those jobs and don't display them.
         result.each do |j|
           if j.status.state != :completed && j.id !~ /\[\]/
-            jobs.push(Jobstatusdata.new(j, cluster.id.to_s))
+            jobs.push(Jobstatusdata.new(j, cluster))
           end
         end
       end

--- a/app/models/jobstatusdata.rb
+++ b/app/models/jobstatusdata.rb
@@ -21,9 +21,8 @@ class Jobstatusdata
   # @param [Boolean, nil] extended If true, included extended data in the response (default: false)
   # @return [Jobstatusdata] self
   def initialize(info, cluster=OODClusters.first.id.to_s, extended=false)
-    if OODClusters[cluster].nil?
-      raise ArgumentError.new("Invalid cluster: #{cluster}")
-    end
+    raise ArgumentError, "Invalid cluster: #{cluster}" unless OODClusters[cluster]
+
     self.pbsid = info.id
     self.jobname = info.job_name
     self.username = info.job_owner

--- a/app/models/jobstatusdata.rb
+++ b/app/models/jobstatusdata.rb
@@ -21,13 +21,16 @@ class Jobstatusdata
   # @param [Boolean, nil] extended If true, included extended data in the response (default: false)
   # @return [Jobstatusdata] self
   def initialize(info, cluster=OODClusters.first.id.to_s, extended=false)
+    if OODClusters[cluster].nil?
+      raise ArgumentError.new("Invalid cluster: #{cluster}")
+    end
     self.pbsid = info.id
     self.jobname = info.job_name
     self.username = info.job_owner
     self.account = info.accounting_id
     self.status = status_label(info.status.state.to_s)
     self.cluster = cluster
-    self.cluster_title = build_title(cluster)
+    self.cluster_title = OODClusters[cluster].metadata.title ||  cluster.titleize
     self.walltime_used = info.wallclock_time.to_i > 0 ? pretty_time(info.wallclock_time) : ''
     self.queue = info.queue_name
     if info.status == :running || info.status == :completed
@@ -170,16 +173,6 @@ class Jobstatusdata
     # @return [Array<String>] the nodes as array
     def node_array(node_info_array)
       node_info_array.map { |n| n.name }
-    end
-
-    # Return the metadata title of a cluster or the titleized key
-    #
-    # @param [String, Symbol] cluster_key A key for a cluster in the OODClusters array
-    # @return [String, nil] The title of the cluster or nil if unassigned
-    def build_title(cluster_key)
-      if cluster_key && OODClusters[cluster_key]
-        OODClusters[cluster_key].metadata.title ||  cluster_key.titleize
-      end
     end
 
     attr_writer :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs

--- a/app/models/jobstatusdata.rb
+++ b/app/models/jobstatusdata.rb
@@ -56,6 +56,7 @@ class Jobstatusdata
   def extended_data_torque(info)
     return unless info.native
     attributes = []
+    attributes.push Attribute.new "Cluster", self.cluster_title
     attributes.push Attribute.new "PBS Id", self.pbsid
     attributes.push Attribute.new "Job Name", self.jobname
     attributes.push Attribute.new "User", self.username
@@ -89,12 +90,12 @@ class Jobstatusdata
   def extended_data_slurm(info)
     return unless info.native
     attributes = []
+    attributes.push Attribute.new "Cluster", self.cluster_title
     attributes.push Attribute.new "Job Id", self.pbsid
     attributes.push Attribute.new "Job Name", self.jobname
     attributes.push Attribute.new "User", self.username
     attributes.push Attribute.new "Account", self.account
     attributes.push Attribute.new "Partition", self.queue
-    attributes.push Attribute.new "Cluster", self.cluster
     attributes.push Attribute.new "State", info.native[:state]
     attributes.push Attribute.new "Reason", info.native[:reason]
     attributes.push Attribute.new "Total Nodes", info.native[:nodes]

--- a/app/models/jobstatusdata.rb
+++ b/app/models/jobstatusdata.rb
@@ -7,7 +7,7 @@
 # @version 0.0.1
 class Jobstatusdata
   include ApplicationHelper
-  attr_reader :pbsid, :jobname, :username, :account, :status, :cluster, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs
+  attr_reader :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs
 
   Attribute = Struct.new(:name, :value)
 
@@ -27,6 +27,7 @@ class Jobstatusdata
     self.account = info.accounting_id
     self.status = status_label(info.status.state.to_s)
     self.cluster = cluster
+    self.cluster_title = build_title(cluster)
     self.walltime_used = info.wallclock_time.to_i > 0 ? pretty_time(info.wallclock_time) : ''
     self.queue = info.queue_name
     if info.status == :running || info.status == :completed
@@ -170,6 +171,16 @@ class Jobstatusdata
       node_info_array.map { |n| n.name }
     end
 
-    attr_writer :pbsid, :jobname, :username, :account, :status, :cluster, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs
+    # Return the metadata title of a cluster or the titleized key
+    #
+    # @param [String, Symbol] cluster_key A key for a cluster in the OODClusters array
+    # @return [String, nil] The title of the cluster or nil if unassigned
+    def build_title(cluster_key)
+      if cluster_key && OODClusters[cluster_key]
+        OODClusters[cluster_key].metadata.title ||  cluster_key.titleize
+      end
+    end
+
+    attr_writer :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs
 
 end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -19,7 +19,7 @@
         </button>
         <ul class="dropdown-menu">
           <% OODClusters.each do |cluster| %>
-              <li class="cluster-dropdown-option" id="cluster-id-<%= cluster.id %>" onclick="set_cluster_id('<%= cluster.id %>');"><a href="#"><%= cluster.metadata.title || cluster.id.titleize %></a></li>
+              <li class="cluster-dropdown-option" id="cluster-id-<%= cluster.id %>" onclick="set_cluster_id('<%= cluster.id %>');"><a href="#"><%= cluster.metadata.title || cluster.id.to_s.titleize %></a></li>
           <% end %>
           <li class="divider"></li>
           <li class="cluster-dropdown-option" id="cluster-id-all" onclick="set_cluster_id('all');" data-title="All Clusters"><a href="#">All Clusters</a></li>

--- a/test/models/jobstatusdata_test.rb
+++ b/test/models/jobstatusdata_test.rb
@@ -46,7 +46,7 @@ class JobstatussataTest < ActiveModel::TestCase
       end
 
       test "test cluster #{@test_count}" do
-        assert data.cluster.instance_of?(OodCore::Cluster), data.cluster
+        assert data.cluster.is_a?(String), data.cluster
       end
 
       test "test nodes #{@test_count}" do


### PR DESCRIPTION
Resolves #122 

Uses the metadata.title attribute instead of titlizing the cluster id.