### PR TITLE
Add a bootstrap error message when extended data fails

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -156,12 +156,21 @@ $(document).ready( function() {
                 $( "div[data-jobid='"+row.data().pbsid+"']").hide().html(data.html).fadeIn(250);
                 // Update the status label in the parent row
                 tr.find(".status-label").html(data.status);
-            });
+            })
+              .fail(function(jqXHR, textStatus, errorThrown) {
+                  var error_panel = '<div class="alert alert-danger" role="alert">' +
+                                    '  <strong>Error:</strong> The information could not be displayed. ' +
+                                    '  <em>' + jqXHR.status + ' (' + errorThrown + ')</em>' +
+                                    '</div>';
+                  $( "div[data-jobid='"+row.data().pbsid+"']").hide().html(error_panel).fadeIn(250);
+              });
         }
     });
 
     table.columns.adjust().draw();
 });
+
+
 
 /* Formatting function for dropdown row. */
 function format ( d ) {


### PR DESCRIPTION
Adds a bootstrap alert error message when the extended data ajax request fails.

![ajax_err](https://user-images.githubusercontent.com/2374718/28075794-8b0bcb38-662a-11e7-9040-50e04f08d8fb.png)
