### PR TITLE
Show native comment if one is available (Torque)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Show native comment if one is available (Torque)
+
 ## [v1.4.6] - 2017-07-10
 
 ### Added

--- a/app/models/jobstatusdata.rb
+++ b/app/models/jobstatusdata.rb
@@ -76,6 +76,7 @@ class Jobstatusdata
     attributes.push Attribute.new "CPU Time", info.native.fetch(:resources_used, {})[:cput].presence || '0'
     attributes.push Attribute.new "Memory", info.native.fetch(:resources_used, {})[:mem].presence || "0 b"
     attributes.push Attribute.new "Virtual Memory", info.native.fetch(:resources_used, {})[:vmem].presence || "0 b"
+    attributes.push Attribute.new "Comment", info.native[:comment] if info.native[:comment]
     self.native_attribs = attributes
 
     self.submit_args = info.native[:submit_args].presence || "None"


### PR DESCRIPTION
Resolves #130 

I looked through a few jobs here at OSC and couldn't find any that had an associated native `:comment`. Because of that, this only sets a comment attribute when there's one available. So, it won't show up here, but presumably will at other Torque sites that have configured this option.