### PR TITLE
Add custom error handler to show Datatables errors in an alert div

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -132,10 +132,15 @@ $(document).ready( function() {
                 "autoWidth":        true
             }
         ]
-    });
-        // Optional, if you want full pagination controls.
-        // Check dataTables documentation to learn more about available options.
-        // http://datatables.net/reference/option/pagingType
+    }).on( 'error.dt', function ( e, settings, techNote, message ) {
+        // Event is fired when there's an error loading or parsing the datatable.
+        show_errors(['There was an error getting data from the remote server.']);
+        console.log('Datatables error: ' + message);
+    } );
+
+    // Override the Datatables default error message functionality
+    //   https://datatables.net/reference/event/error
+    $.fn.dataTable.ext.errMode = 'none'
 
     // Add event listener for opening and closing details
     $('#job_status_table tbody').on('click', '.details-control', function () {


### PR DESCRIPTION
Resolves #133 

#133 was partially implemented via #134, and this PR overrides the default javascript alert and displays a general error to the user in a bootstrap alert. A more detailed technical message provided by DataTables is printed to the console for debugging.

![dt error](https://user-images.githubusercontent.com/2374718/28217992-25f16354-6885-11e7-8c70-f77d12e347ed.png)
