### PR TITLE
Add job show route

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -190,7 +190,7 @@ function format ( d ) {
 
 /* A function that builds a job data view */
 function display_job_info( d ) {
-    return          '<tr class="col-xs-12>' +
+    return          '<tr class="col-xs-12">' +
                     '   <div class="col-xs-12">' +
                     '       <tr><div class="job_data" data-jobid="' + d.pbsid + '"></div></tr>' +
                     '   </div>' +
@@ -254,4 +254,32 @@ function set_cluster_id(id) {
 
 function reload_page() {
     window.location = '?' + get_request_params();
+}
+
+
+function build_ganglia_link( host, start_seconds, report_type, node_num, size ) {
+    var ganglia_uri;
+    <% OODClusters.each do |c| %>
+    if (host == '<%= c.id.to_s %>') {
+        <% if c.custom_allow?(:ganglia) %>
+          <% ganglia_cluster = OodCluster::Servers::Ganglia.new(c.custom_config(:ganglia)) %>
+          var ganglia_base = '<%= ganglia_cluster.uri.to_s %>';
+          ganglia_uri = ganglia_base+'&z='+size+'&cs='+start_seconds+'&g='+report_type+'&h=<%= (ganglia_cluster.opt_query.fetch(:h, '') % {h: '\'+node_num+\''}).html_safe %>';
+        <% else %>
+          ganglia_uri = '<%= image_path('unavailable.png') %>';
+        <% end %>
+    }
+    <% end %>
+    return ganglia_uri;
+}
+
+function has_ganglia(host) {
+    <% OODClusters.each do |c| %>
+    if (host == '<%= c.id.to_s %>') {
+        <% if c.custom_allow?(:ganglia) %>
+            return true;
+        <% end %>
+    }
+    <% end %>
+    return false;
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,7 +5,12 @@ class PagesController < ApplicationController
     @jobfilter = get_filter
     @jobcluster = get_cluster
   end
-
+  
+  # Used to show single job details
+  def show
+    @data = get_job(params[:pbsid], get_cluster)
+  end
+  
   # Used to send the data to the Datatable.
   def json
     if params[:pbsid].nil?

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,7 +8,7 @@ class PagesController < ApplicationController
   
   # Used to show single job details
   def show
-    @data = get_job(params[:pbsid], get_cluster)
+    @data = get_job(params[:pbsid], params[:cluster])
   end
   
   # Used to send the data to the Datatable.

--- a/app/views/pages/_extended_panel.html.erb
+++ b/app/views/pages/_extended_panel.html.erb
@@ -13,7 +13,12 @@
           </div>
         </div>
         <div class="col-xs-11" style="word-wrap: break-word;"><%= data.jobname %>
-          <div><%= link_to data.pbsid, show_path(cluster: data.native_attribs.select{|attrib| attrib.name=="Cluster"}[0].value.downcase , pbsid: data.pbsid.to_s) %></div>
+          <% if page=='index' %>
+            <div><%= link_to data.pbsid, show_path(cluster: data.native_attribs.select{|attrib| attrib.name=="Cluster"}[0].value.downcase , pbsid: data.pbsid.to_s) %></div>
+          <% elsif page=='show' %>
+             <div><%= data.pbsid %></div>
+             <div><%= @data.queue.capitalize %></div>
+          <% end %>
         </div>
       </strong>
     </div>

--- a/app/views/pages/_extended_panel.html.erb
+++ b/app/views/pages/_extended_panel.html.erb
@@ -13,7 +13,7 @@
           </div>
         </div>
         <div class="col-xs-11" style="word-wrap: break-word;"><%= data.jobname %>
-          <div><%= link_to data.pbsid, show_path(data.pbsid) %></div>
+          <div><%= link_to data.pbsid, show_path(cluster: data.native_attribs.select{|attrib| attrib.name=="Cluster"}[0].value.downcase , pbsid: data.pbsid.to_s) %></div>
         </div>
       </strong>
     </div>

--- a/app/views/pages/_extended_panel.html.erb
+++ b/app/views/pages/_extended_panel.html.erb
@@ -13,7 +13,7 @@
           </div>
         </div>
         <div class="col-xs-11" style="word-wrap: break-word;"><%= data.jobname %>
-          <div><%= data.pbsid %></div>
+          <div><%= link_to data.pbsid, show_path(data.pbsid) %></div>
         </div>
       </strong>
     </div>

--- a/app/views/pages/extended_data.json.jbuilder
+++ b/app/views/pages/extended_data.json.jbuilder
@@ -1,2 +1,2 @@
-json.html render partial: 'pages/extended_panel.html.erb', :locals => {:data => jobstatusdata}
+json.html render partial: 'pages/extended_panel.html.erb', :locals => {:data => jobstatusdata, :page=>'index'}
 json.status jobstatusdata.status

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -54,30 +54,4 @@
     var filter_id = <%= (@jobfilter ? "'#{@jobfilter}'" : "localStorage.getItem('jobfilter') || '#{Filter.default_id}'").html_safe %>;
     var cluster_id = <%= (@jobcluster ? "'#{@jobcluster}'" : "localStorage.getItem('jobcluster') || 'all'").html_safe %>;
 
-    function build_ganglia_link( host, start_seconds, report_type, node_num, size ) {
-        var ganglia_uri;
-        <% OODClusters.each do |c| %>
-        if (host == '<%= c.id.to_s %>') {
-            <% if c.custom_allow?(:ganglia) %>
-              <% ganglia_cluster = OodCluster::Servers::Ganglia.new(c.custom_config(:ganglia)) %>
-              var ganglia_base = '<%= ganglia_cluster.uri.to_s %>';
-              ganglia_uri = ganglia_base+'&z='+size+'&cs='+start_seconds+'&g='+report_type+'&h=<%= (ganglia_cluster.opt_query.fetch(:h, '') % {h: '\'+node_num+\''}).html_safe %>';
-            <% else %>
-              ganglia_uri = '<%= image_path('unavailable.png') %>';
-            <% end %>
-        }
-        <% end %>
-        return ganglia_uri;
-    }
-
-    function has_ganglia(host) {
-        <% OODClusters.each do |c| %>
-        if (host == '<%= c.id.to_s %>') {
-            <% if c.custom_allow?(:ganglia) %>
-                return true;
-            <% end %>
-        }
-        <% end %>
-        return false;
-    }
 </script>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,0 +1,61 @@
+<% if @data.error %>
+  <div class="alert alert-warning" role="alert">
+    <%= @data.error %>
+  </div>
+<% else %>
+<div>
+  <div class="panel panel-default container-fluid">
+    <div class="panel-heading row clearfix">
+      <strong>
+        <div class="col-xs-1">
+          <div style="white-space: nowrap;">
+            <%= @data.status %>
+          </div>
+        </div>
+        <div class="col-xs-11" style="word-wrap: break-word;"><%= @data.jobname %>
+          <div><%= @data.pbsid %></div>
+        </div>
+      </strong>
+    </div>
+    <div class="panel-body">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <table class="table table-condensed table-striped">
+            <tbody>
+            <% @data.native_attribs.each do |attrib| %>
+              <tr>
+                <td class="col-xs-2"><strong><%= attrib.name %></strong></td>
+                <td class="col-xs-10"><%= attrib.value %></td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+      <% if @data.submit_args %>
+      <div class="col-md-12">
+        <span class="col-md-2">Submit Args: </span>
+        <pre class="col-md-10" style="white-space: pre-wrap;"><%= @data.submit_args %></pre>
+      </div>
+      <% end %>
+      <% if @data.output_path %>
+      <div class="col-md-12">
+        <span class="col-md-2">Output Location: </span>
+        <pre class="col-md-10" style="white-space: pre-wrap;"><%= @data.output_path %></pre>
+      </div>
+      <% end %>
+      <div class="col-md-12">
+        <% if ENV["USER"] == @data.username %>
+            <%= link_to "#{icon("folder-open")} Open in File Manager".html_safe, @data.file_explorer_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if @data.file_explorer_url %>
+            <%= link_to "#{icon("terminal")} Open in Terminal".html_safe, @data.shell_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if @data.shell_url %>
+            <%= link_to "#{icon("trash-o")} Delete".html_safe, delete_job_path(pbsid: @data.pbsid, cluster: @data.cluster), :class => "btn btn-danger pull-right", :style => "margin: 10px;", data: { method: "delete", confirm: "Are you sure you want to delete #{@data.pbsid}" } %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+<% end %>
+
+
+<%= link_to 'Back', root_path %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -14,6 +14,7 @@
         </div>
         <div class="col-xs-11" style="word-wrap: break-word;"><%= @data.jobname %>
           <div><%= @data.pbsid %></div>
+          <div><%= @data.queue.capitalize %></div>
         </div>
       </strong>
     </div>
@@ -53,9 +54,12 @@
         <% end %>
       </div>
     </div>
+    <table id="showpage_nodes"></table>
   </div>
-</div>
+   <%= link_to 'Back', root_path, class:["btn","btn-primary"],type:"button"%>
+ </div>
 <% end %>
-
-
-<%= link_to 'Back', root_path %>
+<script>
+    var filter_id,cluster_id;
+    document.getElementById('showpage_nodes').insertAdjacentHTML('afterbegin', display_node_rows(<%= @data.to_json.html_safe %>));
+</script>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -3,59 +3,9 @@
     <%= @data.error %>
   </div>
 <% else %>
-<div>
-  <div class="panel panel-default container-fluid">
-    <div class="panel-heading row clearfix">
-      <strong>
-        <div class="col-xs-1">
-          <div style="white-space: nowrap;">
-            <%= @data.status %>
-          </div>
-        </div>
-        <div class="col-xs-11" style="word-wrap: break-word;"><%= @data.jobname %>
-          <div><%= @data.pbsid %></div>
-          <div><%= @data.queue.capitalize %></div>
-        </div>
-      </strong>
-    </div>
-    <div class="panel-body">
-      <div class="col-md-12">
-        <div class="panel panel-default">
-          <table class="table table-condensed table-striped">
-            <tbody>
-            <% @data.native_attribs.each do |attrib| %>
-              <tr>
-                <td class="col-xs-2"><strong><%= attrib.name %></strong></td>
-                <td class="col-xs-10"><%= attrib.value %></td>
-              </tr>
-            <% end %>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-      <% if @data.submit_args %>
-      <div class="col-md-12">
-        <span class="col-md-2">Submit Args: </span>
-        <pre class="col-md-10" style="white-space: pre-wrap;"><%= @data.submit_args %></pre>
-      </div>
-      <% end %>
-      <% if @data.output_path %>
-      <div class="col-md-12">
-        <span class="col-md-2">Output Location: </span>
-        <pre class="col-md-10" style="white-space: pre-wrap;"><%= @data.output_path %></pre>
-      </div>
-      <% end %>
-      <div class="col-md-12">
-        <% if ENV["USER"] == @data.username %>
-            <%= link_to "#{icon("folder-open")} Open in File Manager".html_safe, @data.file_explorer_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if @data.file_explorer_url %>
-            <%= link_to "#{icon("terminal")} Open in Terminal".html_safe, @data.shell_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if @data.shell_url %>
-            <%= link_to "#{icon("trash-o")} Delete".html_safe, delete_job_path(pbsid: @data.pbsid, cluster: @data.cluster), :class => "btn btn-danger pull-right", :style => "margin: 10px;", data: { method: "delete", confirm: "Are you sure you want to delete #{@data.pbsid}" } %>
-        <% end %>
-      </div>
-    </div>
+<div class="show">
+    <%= render partial: 'pages/extended_panel.html.erb', :locals => {:data => @data, :page=>'show'} %>
     <table id="showpage_nodes"></table>
-  </div>
    <%= link_to 'Back', root_path, class:["btn","btn-primary"],type:"button"%>
  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 JobStatus::Application.routes.draw do
   root "pages#index"
   get "pages/index"
-  get '/show/:id', to: 'pages#show', as: 'show'
-  get '/show' => redirect('/')
+  get ":cluster/:pbsid" => "pages#show", :pbsid => /[0-9]+\.[a-z]+-[a-z]+\.ten\.osc\.edu|[0-9]+/, as: "show"
+#   get '/show' => redirect('/')
   #get "pages/about"
   get "/json" => "pages#json", :defaults => { :format => 'json' }
   delete "/delete_job" => "pages#delete_job"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ JobStatus::Application.routes.draw do
   root "pages#index"
   get "pages/index"
   get ":cluster/:pbsid" => "pages#show", :pbsid => /[0-9]+\.[a-z]+-[a-z]+\.ten\.osc\.edu|[0-9]+/, as: "show"
-#   get '/show' => redirect('/')
   #get "pages/about"
   get "/json" => "pages#json", :defaults => { :format => 'json' }
   delete "/delete_job" => "pages#delete_job"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 JobStatus::Application.routes.draw do
   root "pages#index"
   get "pages/index"
+  get '/show/:id', to: 'pages#show', as: 'show'
+  get '/show' => redirect('/')
   #get "pages/about"
   get "/json" => "pages#json", :defaults => { :format => 'json' }
   delete "/delete_job" => "pages#delete_job"


### PR DESCRIPTION
Because index and show page share build_ganglia_link and has_ganglia functions, so I moved them from index.html.erb to application.js. 

```
function build_ganglia_link( host, start_seconds, report_type, node_num, size ) {	
        var ganglia_uri;	
        <% OODClusters.each do |c| %>	
        if (host == '<%= c.id.to_s %>') {	
            <% if c.custom_allow?(:ganglia) %>	
              <% ganglia_cluster = OodCluster::Servers::Ganglia.new(c.custom_config(:ganglia)) %>	
              var ganglia_base = '<%= ganglia_cluster.uri.to_s %>';	
              ganglia_uri = ganglia_base+'&z='+size+'&cs='+start_seconds+'&g='+report_type+'&h=<%= (ganglia_cluster.opt_query.fetch(:h, '') % {h: '\'+node_num+\''}).html_safe %>';	
            <% else %>	
              ganglia_uri = '<%= image_path('unavailable.png') %>';	
            <% end %>	
        }	
        <% end %>	
        return ganglia_uri;	
    }	
     function has_ganglia(host) {	
        <% OODClusters.each do |c| %>	
        if (host == '<%= c.id.to_s %>') {	
            <% if c.custom_allow?(:ganglia) %>	
                return true;	
            <% end %>	
        }	
        <% end %>	
        return false;	
    }
```

#### Index page: 
- Add a link to the job id in the panel header

![screencapture-ondemand-test-osc-edu-pun-dev-active_jobs-2018-07-27-14_52_11](https://user-images.githubusercontent.com/22674713/43343282-aeadec5a-91b3-11e8-8044-80743ae97729.png)



#### Individual show page: 
- Add Queue after the job id in the panel header
- Add back to index page button at the end of job information
- The route is `/:cluster/:pbsid`  i.e.`https://ondemand-test.osc.edu/pun/dev/Active_jobs/owens/3542123.owens-batch.ten.osc.edu`

![screencapture-ondemand-test-osc-edu-pun-dev-active_jobs-owens-3538102-owens-batch-ten-osc-edu-2018-07-27-14_52_43](https://user-images.githubusercontent.com/22674713/43341756-6d6efc8e-91ae-11e8-9ecb-4ed00d9d3ded.png)

close #160 