### PR TITLE
update 404 and 500 pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,27 @@
+class ErrorsController < ApplicationController
+  # https://mattbrictson.com/dynamic-rails-error-pages
+  #
+  # to test in development, comment out this line in
+  # config/environments/devleopment.rb:
+  #
+  #     config.consider_all_requests_local       = true
+  #
+  # the routes.rb is set to the app to handle exceptions in application.rb
+  #
+  def not_found
+    render status: 404
+  end
+
+  def internal_server_error
+    @exception  = env['action_dispatch.exception']
+
+
+    # FIXME: a better solution exists than this
+    # avoid rendering nav in case those introduce exceptions
+    @hidenav = true
+
+    #TODO: log exception information you want to log here
+    # after removing it from the normal logging via lograge
+    render status: 500
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,4 +23,8 @@ module ApplicationHelper
     end
     "<div style='white-space: nowrap;'><span class='label #{labelclass}'>#{label}</span></div>".html_safe
   end
+  
+  def support_url
+    ENV['OOD_DASHBOARD_SUPPORT_URL'] || "https://www.osc.edu/contact/supercomputing_support"
+  end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,3 +1,3 @@
 module PagesHelper
-    
+
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,3 +1,3 @@
 module PagesHelper
-
+    
 end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,7 +1,8 @@
 <div class="jumbotron">
   <h1>Internal Server Error</h1>
   <p>Please try again in a few moments. 
-  If you continue to see this error, please contact support.
+  If you continue to see this error, please
+  <a href="<%= support_url %>">contact support</a>.
   </p>
 
 

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,16 @@
+<div class="jumbotron">
+  <h1>Internal Server Error</h1>
+  <p>Please try again in a few moments. 
+  If you continue to see this error, please contact support.
+  </p>
+
+
+</div>
+
+<h3>Details:</h3>
+
+<pre>
+<%= @exception.inspect if @exception %>
+
+<%= @exception.backtrace.join("\n") if @exception  %>
+</pre>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,4 @@
+<div class="jumbotron">
+  <h1>Not Found</h1>
+  <p>The page you are looking for does not exist.</p>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,10 @@ module JobStatus
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-
+    
+    # Custom error pages
+    config.exceptions_app = self.routes
+    
     if ::Configuration.load_external_config?
       config.paths["config/initializers"] << ::Configuration.custom_initializers_root.to_s
       config.paths["app/views"].unshift ::Configuration.custom_views_root.to_s

--- a/config/examples/awesim/env
+++ b/config/examples/awesim/env
@@ -1,2 +1,3 @@
 OOD_PORTAL="awesim"
 OOD_DASHBOARD_TITLE="AweSim Apps"
+OOD_DASHBOARD_SUPPORT_URL="https://www.osc.edu/contact/supercomputing_support"

--- a/config/examples/ondemand/env
+++ b/config/examples/ondemand/env
@@ -1,2 +1,3 @@
 OOD_PORTAL="ondemand"
 OOD_DASHBOARD_TITLE="OSC OnDemand"
+OOD_DASHBOARD_SUPPORT_URL="https://www.osc.edu/contact/supercomputing_support"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ JobStatus::Application.routes.draw do
   #get "pages/about"
   get "/json" => "pages#json", :defaults => { :format => 'json' }
   delete "/delete_job" => "pages#delete_job"
+  get "errors/not_found"
+  get "errors/internal_server_error"
+  match "/404", :to => "errors#not_found", :via => :all
+  match "/500", :to => "errors#internal_server_error", :via => :all
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class ErrorsControllerTest < ActionController::TestCase
+  test "should get not_found" do
+    get :not_found
+    assert_response 404
+  end
+
+  test "should get internal_server_error" do
+    get :internal_server_error
+    assert_response 500
+  end
+
+end


### PR DESCRIPTION
- custom error pages enabled. 
- not_found and internal_server_error views updated.

#### /errors/not_found
![404](https://user-images.githubusercontent.com/22674713/43976768-cfc1b0e6-9caf-11e8-8704-c8f3df3d2392.JPG)

#### /errors/internal_server_error
![500](https://user-images.githubusercontent.com/22674713/43976774-d35024f4-9caf-11e8-972f-fa87dcc19695.JPG)

fix #62 