### PR TITLE
add submission time, queued time 

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -211,10 +211,10 @@ function display_node_rows( d ) {
                     '           <div class="panel panel-default">' +
                     '              <div class="panel-heading"><h3 class="panel-title">' + node_num + ' <span class="pull-right">' + d.pbsid + '</span></h3></div>' +
                     '              <div class="panel-body">' +
-                    '                   <a href="'+ build_ganglia_link(d.cluster, start, 'cpu_report', node_num, 'large') +'" data-lightbox="cpu-report" data-title="CPU Report '+node_num+'"><img class="img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" src="'+build_ganglia_link(d.cluster, start, 'cpu_report', node_num, 'small')+'" /></a>' +
-                    '                   <a href="'+ build_ganglia_link(d.cluster, start, 'load_report', node_num, 'large') +'" data-lightbox="load-report" data-title="Load Report '+node_num+'"><img class="img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" src="'+build_ganglia_link(d.cluster, start, 'load_report', node_num, 'small')+'" /></a>' +
-                    '                   <a href="'+ build_ganglia_link(d.cluster, start, 'mem_report', node_num, 'large') +'" data-lightbox="mem-report" data-title="Memory Report '+node_num+'"><img class="img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" src="'+build_ganglia_link(d.cluster, start, 'mem_report', node_num, 'small')+'" /></a>' +
-                    '                   <a href="'+ build_ganglia_link(d.cluster, start, 'network_report', node_num, 'large') +'" data-lightbox="network-report" data-title="Network Report '+node_num+'"><img class="img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" src="'+build_ganglia_link(d.cluster, start, 'network_report', node_num, 'small')+'" /></a>' +
+                    '                   <a href="'+ build_ganglia_link(d.cluster, start, 'cpu_report', node_num, '1200,600') +'" data-lightbox="cpu-report" data-title="CPU Report '+node_num+'"><img class="img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" src="'+build_ganglia_link(d.cluster, start, 'cpu_report', node_num, 'small')+'" /></a>' +
+                    '                   <a href="'+ build_ganglia_link(d.cluster, start, 'load_report', node_num, '1200,600') +'" data-lightbox="load-report" data-title="Load Report '+node_num+'"><img class="img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" src="'+build_ganglia_link(d.cluster, start, 'load_report', node_num, 'small')+'" /></a>' +
+                    '                   <a href="'+ build_ganglia_link(d.cluster, start, 'mem_report', node_num, '1200,600') +'" data-lightbox="mem-report" data-title="Memory Report '+node_num+'"><img class="img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" src="'+build_ganglia_link(d.cluster, start, 'mem_report', node_num, 'small')+'" /></a>' +
+                    '                   <a href="'+ build_ganglia_link(d.cluster, start, 'network_report', node_num, '1200,600') +'" data-lightbox="network-report" data-title="Network Report '+node_num+'"><img class="img-responsive col-lg-3 col-md-3 col-sm-6 col-xs-6" src="'+build_ganglia_link(d.cluster, start, 'network_report', node_num, 'small')+'" /></a>' +
                     '              </div>' +
                     '           </div>' +
                     '       </td>' +
@@ -264,7 +264,11 @@ function build_ganglia_link( host, start_seconds, report_type, node_num, size ) 
         <% if c.custom_allow?(:ganglia) %>
           <% ganglia_cluster = OodCluster::Servers::Ganglia.new(c.custom_config(:ganglia)) %>
           var ganglia_base = '<%= ganglia_cluster.uri.to_s %>';
-          ganglia_uri = ganglia_base+'&z='+size+'&cs='+start_seconds+'&g='+report_type+'&h=<%= (ganglia_cluster.opt_query.fetch(:h, '') % {h: '\'+node_num+\''}).html_safe %>';
+          if(size.indexOf(',') >0){
+            ganglia_uri = ganglia_base+'&width='+size.substring(0, size.indexOf(','))+'&height='+size.substring(size.indexOf(',')+1) +'&cs='+start_seconds+'&g='+report_type+'&h=<%= (ganglia_cluster.opt_query.fetch(:h, '') % {h: '\'+node_num+\''}).html_safe %>';
+          }else{
+            ganglia_uri = ganglia_base+'&z='+size+'&cs='+start_seconds+'&g='+report_type+'&h=<%= (ganglia_cluster.opt_query.fetch(:h, '') % {h: '\'+node_num+\''}).html_safe %>';
+          }
         <% else %>
           ganglia_uri = '<%= image_path('unavailable.png') %>';
         <% end %>

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -190,7 +190,7 @@ function format ( d ) {
 
 /* A function that builds a job data view */
 function display_job_info( d ) {
-    return          '<tr class="col-xs-12>' +
+    return          '<tr class="col-xs-12">' +
                     '   <div class="col-xs-12">' +
                     '       <tr><div class="job_data" data-jobid="' + d.pbsid + '"></div></tr>' +
                     '   </div>' +
@@ -254,4 +254,32 @@ function set_cluster_id(id) {
 
 function reload_page() {
     window.location = '?' + get_request_params();
+}
+
+
+function build_ganglia_link( host, start_seconds, report_type, node_num, size ) {
+    var ganglia_uri;
+    <% OODClusters.each do |c| %>
+    if (host == '<%= c.id.to_s %>') {
+        <% if c.custom_allow?(:ganglia) %>
+          <% ganglia_cluster = OodCluster::Servers::Ganglia.new(c.custom_config(:ganglia)) %>
+          var ganglia_base = '<%= ganglia_cluster.uri.to_s %>';
+          ganglia_uri = ganglia_base+'&z='+size+'&cs='+start_seconds+'&g='+report_type+'&h=<%= (ganglia_cluster.opt_query.fetch(:h, '') % {h: '\'+node_num+\''}).html_safe %>';
+        <% else %>
+          ganglia_uri = '<%= image_path('unavailable.png') %>';
+        <% end %>
+    }
+    <% end %>
+    return ganglia_uri;
+}
+
+function has_ganglia(host) {
+    <% OODClusters.each do |c| %>
+    if (host == '<%= c.id.to_s %>') {
+        <% if c.custom_allow?(:ganglia) %>
+            return true;
+        <% end %>
+    }
+    <% end %>
+    return false;
 }

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,27 @@
+class ErrorsController < ApplicationController
+  # https://mattbrictson.com/dynamic-rails-error-pages
+  #
+  # to test in development, comment out this line in
+  # config/environments/devleopment.rb:
+  #
+  #     config.consider_all_requests_local       = true
+  #
+  # the routes.rb is set to the app to handle exceptions in application.rb
+  #
+  def not_found
+    render status: 404
+  end
+
+  def internal_server_error
+    @exception  = env['action_dispatch.exception']
+
+
+    # FIXME: a better solution exists than this
+    # avoid rendering nav in case those introduce exceptions
+    @hidenav = true
+
+    #TODO: log exception information you want to log here
+    # after removing it from the normal logging via lograge
+    render status: 500
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,7 +5,12 @@ class PagesController < ApplicationController
     @jobfilter = get_filter
     @jobcluster = get_cluster
   end
-
+  
+  # Used to show single job details
+  def show
+    @data = get_job(params[:pbsid], params[:cluster])
+  end
+  
   # Used to send the data to the Datatable.
   def json
     if params[:pbsid].nil?
@@ -43,6 +48,44 @@ class PagesController < ApplicationController
       end
     else
       redirect_to root_url, :alert => "Failed to delete."
+    end
+  end
+  
+   def hold_job
+
+    # Only hold if the pbsid and host params are present and host is configured in servers.
+    # PBS will prevent a user from holding a job that is not their own and throw an error.
+    cluster = OODClusters[params[:cluster].to_sym]
+    if (params[:pbsid] && cluster)
+      job_id = params[:pbsid].to_s.gsub(/_/, '.')
+
+      begin
+        cluster.job_adapter.hold(job_id)
+        redirect_to :back, :notice => "Successfully held " + job_id
+      rescue
+        redirect_to :back, :alert => "Failed to hold " + job_id
+      end
+    else
+      redirect_to :back, :alert => "Failed to hold."
+    end
+  end
+  
+   def release_job
+
+    # Only release if the pbsid and host params are present and host is configured in servers.
+    # PBS will prevent a user from releasing a job that is not their own and throw an error.
+    cluster = OODClusters[params[:cluster].to_sym]
+    if (params[:pbsid] && cluster)
+      job_id = params[:pbsid].to_s.gsub(/_/, '.')
+
+      begin
+        cluster.job_adapter.release(job_id)
+        redirect_to :back, :notice => "Successfully released " + job_id
+      rescue
+        redirect_to :back, :alert => "Failed to release " + job_id
+      end
+    else
+      redirect_to :back, :alert => "Failed to release."
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,4 +23,8 @@ module ApplicationHelper
     end
     "<div style='white-space: nowrap;'><span class='label #{labelclass}'>#{label}</span></div>".html_safe
   end
+  
+  def support_url
+    ENV['OOD_DASHBOARD_SUPPORT_URL']
+  end
 end

--- a/app/models/jobstatusdata.rb
+++ b/app/models/jobstatusdata.rb
@@ -7,7 +7,7 @@
 # @version 0.0.1
 class Jobstatusdata
   include ApplicationHelper
-  attr_reader :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error, :status_text, :submission_time, :queued_time, :walltime
+  attr_reader :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error, :status_text, :submission_time, :queued_time
 
   Attribute = Struct.new(:name, :value)
 
@@ -270,6 +270,6 @@ class Jobstatusdata
       node_info_array.map { |n| n.name }
     end
 
-    attr_writer :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error, :status_text, :submission_time, :queued_time, :walltime
+    attr_writer :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error, :status_text, :submission_time, :queued_time
 
 end

--- a/app/models/jobstatusdata.rb
+++ b/app/models/jobstatusdata.rb
@@ -33,7 +33,7 @@ class Jobstatusdata
     self.cluster = cluster.id.to_s
     self.cluster_title = cluster.metadata.title ||  cluster.id.to_s.titleize
     self.walltime_used = info.wallclock_time.to_i > 0 ? pretty_time(info.wallclock_time) : ''
-    self.walltime = info.wallclock_limit
+    self.walltime = pretty_time(info.wallclock_limit)
     self.queue = info.queue_name
     self.submission_time= info.submission_time
     if info.status == :running || info.status == :completed
@@ -74,7 +74,7 @@ class Jobstatusdata
     attributes.push Attribute.new "Job Name", self.jobname
     attributes.push Attribute.new "User", self.username
     attributes.push Attribute.new "Account", self.account
-    attributes.push Attribute.new "Walltime", pretty_time(self.walltime)
+    attributes.push Attribute.new "Walltime", self.walltime
     attributes.push Attribute.new "Walltime Used", self.walltime_used
     node_count = info.native.fetch(:Resource_List, {})[:nodect].to_i
     attributes.push Attribute.new "Node Count", node_count
@@ -185,7 +185,7 @@ class Jobstatusdata
     attributes.push Attribute.new "User", self.username
     attributes.push Attribute.new "Account", self.account if info.accounting_id
     attributes.push Attribute.new "Group List", info.native[:group_list] if info.native[:group_list]
-    attributes.push Attribute.new "Walltime", pretty_time(self.walltime)
+    attributes.push Attribute.new "Walltime", self.walltime
     walltime_used = info.wallclock_time || 0
     attributes.push Attribute.new "Walltime Used", self.walltime_used
     node_count = info.native.fetch(:Resource_List, {})[:nodect].to_i

--- a/app/models/jobstatusdata.rb
+++ b/app/models/jobstatusdata.rb
@@ -7,7 +7,7 @@
 # @version 0.0.1
 class Jobstatusdata
   include ApplicationHelper
-  attr_reader :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error
+  attr_reader :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error, :status_text
 
   Attribute = Struct.new(:name, :value)
 
@@ -28,6 +28,7 @@ class Jobstatusdata
     self.jobname = info.job_name
     self.username = info.job_owner
     self.account = info.accounting_id || ''
+    self.status_text = info.status.state.to_s
     self.status = status_label(info.status.state.to_s)
     self.cluster = cluster.id.to_s
     self.cluster_title = cluster.metadata.title ||  cluster.id.to_s.titleize
@@ -258,6 +259,6 @@ class Jobstatusdata
       node_info_array.map { |n| n.name }
     end
 
-    attr_writer :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error
+    attr_writer :pbsid, :jobname, :username, :account, :status, :cluster, :cluster_title, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :shell_url, :file_explorer_url, :extended_available, :native_attribs, :error, :status_text
 
 end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,15 @@
+<div class="jumbotron">
+  <h1>Internal Server Error</h1>
+  <p>Please try again in a few moments. 
+  If you continue to see this error, please
+  <a href="<%= support_url %>">contact support</a>.
+  </p>
+</div>
+
+<h3>Details:</h3>
+
+<pre>
+<%= @exception.inspect if @exception %>
+
+<%= @exception.backtrace.join("\n") if @exception  %>
+</pre>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,4 @@
+<div class="jumbotron">
+  <h1>Not Found</h1>
+  <p>The page you are looking for does not exist.</p>
+</div>

--- a/app/views/pages/_extended_panel.html.erb
+++ b/app/views/pages/_extended_panel.html.erb
@@ -12,8 +12,9 @@
             <%= data.status %>
           </div>
         </div>
-        <div class="col-xs-11" style="word-wrap: break-word;"><%= data.jobname %>
-          <div><%= data.pbsid %></div>
+        <div class="col-xs-11" style="word-wrap: break-word;">
+          <%= link_to "#{data.pbsid} - #{data.queue}", show_path(cluster: data.native_attribs.select{|attrib| attrib.name=="Cluster"}[0].value.downcase , pbsid: data.pbsid.to_s) %><br>
+          <%= data.jobname %>
         </div>
       </strong>
     </div>
@@ -50,6 +51,11 @@
             <%= link_to "#{icon("folder-open")} Open in File Manager".html_safe, data.file_explorer_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if data.file_explorer_url %>
             <%= link_to "#{icon("terminal")} Open in Terminal".html_safe, data.shell_url, :class => "btn btn-default", :target => "_blank", :style => "margin: 10px;" if data.shell_url %>
             <%= link_to "#{icon("trash-o")} Delete".html_safe, delete_job_path(pbsid: data.pbsid, cluster: data.cluster), :class => "btn btn-danger pull-right", :style => "margin: 10px;", data: { method: "delete", confirm: "Are you sure you want to delete #{data.pbsid}" } %>
+            <% if data.status_text =="queued" %>
+                <%= link_to "#{icon("pause")} Hold".html_safe, hold_job_path(pbsid: data.pbsid, cluster: data.cluster), :class => "btn btn-warning pull-right", :style => "margin: 10px;", data: { method: "put"} %>
+            <% elsif data.status_text =="queued_held" %>
+                <%= link_to "#{icon("play")} Release".html_safe, release_job_path(pbsid: data.pbsid, cluster: data.cluster), :class => "btn btn-warning pull-right", :style => "margin: 10px;", data: { method: "put"} %>
+            <% end %> 
         <% end %>
       </div>
     </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -54,30 +54,4 @@
     var filter_id = <%= (@jobfilter ? "'#{@jobfilter}'" : "localStorage.getItem('jobfilter') || '#{Filter.default_id}'").html_safe %>;
     var cluster_id = <%= (@jobcluster ? "'#{@jobcluster}'" : "localStorage.getItem('jobcluster') || 'all'").html_safe %>;
 
-    function build_ganglia_link( host, start_seconds, report_type, node_num, size ) {
-        var ganglia_uri;
-        <% OODClusters.each do |c| %>
-        if (host == '<%= c.id.to_s %>') {
-            <% if c.custom_allow?(:ganglia) %>
-              <% ganglia_cluster = OodCluster::Servers::Ganglia.new(c.custom_config(:ganglia)) %>
-              var ganglia_base = '<%= ganglia_cluster.uri.to_s %>';
-              ganglia_uri = ganglia_base+'&z='+size+'&cs='+start_seconds+'&g='+report_type+'&h=<%= (ganglia_cluster.opt_query.fetch(:h, '') % {h: '\'+node_num+\''}).html_safe %>';
-            <% else %>
-              ganglia_uri = '<%= image_path('unavailable.png') %>';
-            <% end %>
-        }
-        <% end %>
-        return ganglia_uri;
-    }
-
-    function has_ganglia(host) {
-        <% OODClusters.each do |c| %>
-        if (host == '<%= c.id.to_s %>') {
-            <% if c.custom_allow?(:ganglia) %>
-                return true;
-            <% end %>
-        }
-        <% end %>
-        return false;
-    }
 </script>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,0 +1,15 @@
+<% if @data.error %>
+  <div class="alert alert-warning" role="alert">
+    <%= @data.error %>
+  </div>
+<% else %>
+<div class="show">
+    <%= render partial: 'pages/extended_panel.html.erb', :locals => {:data => @data} %>
+    <table id="showpage_nodes"></table>
+   <%= link_to 'Back', root_path, class:["btn","btn-primary"],type:"button"%>
+ </div>
+<% end %>
+<script>
+    var filter_id,cluster_id;
+    document.getElementById('showpage_nodes').insertAdjacentHTML('afterbegin', display_node_rows(<%= @data.to_json.html_safe %>));
+</script>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,10 @@ module JobStatus
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-
+    
+    # Custom error pages
+    config.exceptions_app = self.routes
+    
     if ::Configuration.load_external_config?
       config.paths["config/initializers"] << ::Configuration.custom_initializers_root.to_s
       config.paths["app/views"].unshift ::Configuration.custom_views_root.to_s

--- a/config/examples/awesim/env
+++ b/config/examples/awesim/env
@@ -1,2 +1,3 @@
 OOD_PORTAL="awesim"
 OOD_DASHBOARD_TITLE="AweSim Apps"
+OOD_DASHBOARD_SUPPORT_URL="https://www.osc.edu/contact/supercomputing_support"

--- a/config/examples/ondemand/env
+++ b/config/examples/ondemand/env
@@ -1,2 +1,3 @@
 OOD_PORTAL="ondemand"
 OOD_DASHBOARD_TITLE="OSC OnDemand"
+OOD_DASHBOARD_SUPPORT_URL="https://www.osc.edu/contact/supercomputing_support"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,16 @@
 JobStatus::Application.routes.draw do
   root "pages#index"
   get "pages/index"
-  #get "pages/about"
+  get ":cluster/:pbsid" => "pages#show", :pbsid => /.+\.osc\.edu|[0-9]+/, as: "show"
   get "/json" => "pages#json", :defaults => { :format => 'json' }
   delete "/delete_job" => "pages#delete_job"
+  put "/hold_job" => "pages#hold_job"
+  put "/release_job" => "pages#release_job"
+  get "errors/not_found"
+  get "errors/internal_server_error"
+  match "/404", :to => "errors#not_found", :via => :all
+  match "/500", :to => "errors#internal_server_error", :via => :all
+  #get "pages/about"
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class ErrorsControllerTest < ActionController::TestCase
+  test "should get not_found" do
+    get :not_found
+    assert_response 404
+  end
+
+  test "should get internal_server_error" do
+    get :internal_server_error
+    assert_response 500
+  end
+
+end

--- a/vendor/assets/components/lightbox2/javascripts/lightbox.js
+++ b/vendor/assets/components/lightbox2/javascripts/lightbox.js
@@ -22,8 +22,8 @@
       this.alwaysShowNavOnTouchDevices = false;
       this.fadeDuration                = 20;
       this.fitImagesInViewport         = true;
-      // this.maxWidth                    = 800;
-      // this.maxHeight                   = 600;
+      this.maxWidth                    = window.innerWidth;
+      this.maxHeight                   = window.innerHeight;
       this.positionFromTop             = 50;
       this.resizeDuration              = 20;
       this.showImageNumberLabel        = true;


### PR DESCRIPTION
#### Submission and Queued time are appended at the end of details. Walltime is updated to use info.wallclock_limit
![time](https://user-images.githubusercontent.com/22674713/44682472-78a44e80-aa11-11e8-984c-34745114cacf.JPG)

Question:
Queued time is available for all the jobs right now. Do we want to limit this field to Queued job only?

#### Pop-up graph will be resized to 1200*600 after user clicks it

![large](https://user-images.githubusercontent.com/22674713/44686280-b3ab7f80-aa1b-11e8-8daa-f7ba8093f9a9.JPG)

fixed #59, #129, #146 , #7 