### PR TITLE
Fix invalid job cluster request

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -22,6 +22,9 @@
 var APP_PATH = window.location.pathname;
 
 $(document).ready( function() {
+    if ( !validClusters.includes(cluster_id) && cluster_id != 'all' ) {
+      set_cluster_id(defaultCluster);
+    }
     $("#selected-filter-label").text($("#filter-id-"+filter_id).text());
     $("#selected-cluster-label").text($("#cluster-id-"+cluster_id).text());
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -92,44 +92,49 @@ class PagesController < ApplicationController
     errors = Array.new
     jobfilter = get_filter
     jobcluster = get_cluster
+    
+    if jobcluster.nil?
+      errors << "'#{params[:jobcluster]}' is not a defined cluster\n"
+      return { data: jobs, errors: errors }
+    else
+      OODClusters.each do |cluster|
 
-    OODClusters.each do |cluster|
+        if jobcluster == 'all' || cluster == OODClusters[jobcluster]
 
-      if jobcluster == 'all' || cluster == OODClusters[jobcluster]
+          b = cluster.job_adapter
 
-        b = cluster.job_adapter
-
-        begin
-          if jobfilter == 'user'
-            result = b.info_where_owner(OodSupport::User.new.name)
-          else
-            filter = Filter.list.find { |f| f.filter_id == jobfilter }
-            result = filter ? filter.apply(b.info_all) : b.info_all
-          end
-
-          # Only add the running jobs to the list and assign the host to the object.
-          #
-          # There is also curently a bug in the system where jobs with an empty array
-          # (ex. 6407991[].oak-batch.osc.edu) are not stattable, so we do a not-match
-          # for those jobs and don't display them.
-          result.each do |j|
-            if j.status.state != :completed && j.id !~ /\[\]/
-              jobs.push(Jobstatusdata.new(j, cluster))
+          begin
+            if jobfilter == 'user'
+              result = b.info_where_owner(OodSupport::User.new.name)
+            else
+              filter = Filter.list.find { |f| f.filter_id == jobfilter }
+              result = filter ? filter.apply(b.info_all) : b.info_all
             end
+
+            # Only add the running jobs to the list and assign the host to the object.
+            #
+            # There is also curently a bug in the system where jobs with an empty array
+            # (ex. 6407991[].oak-batch.osc.edu) are not stattable, so we do a not-match
+            # for those jobs and don't display them.
+            result.each do |j|
+              if j.status.state != :completed && j.id !~ /\[\]/
+                jobs.push(Jobstatusdata.new(j, cluster))
+              end
+            end
+          rescue => e
+            msg = "#{cluster.metadata.title || cluster.id.to_s.titleize}: #{e.message}"
+            logger.error "#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
+            errors << msg
           end
-        rescue => e
-          msg = "#{cluster.metadata.title || cluster.id.to_s.titleize}: #{e.message}"
-          logger.error "#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
-          errors << msg
         end
       end
-    end
 
-    # Sort jobs by username
-    jobs.sort_by! do |user|
-      user.username == OodSupport::User.new.name ? 0 : 1
+      # Sort jobs by username
+      jobs.sort_by! do |user|
+        user.username == OodSupport::User.new.name ? 0 : 1
+      end
     end
-
+    
     { data: jobs, errors: errors }
   end
 end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -17,6 +17,10 @@
         <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <span id="selected-cluster-label"></span> <span class="caret"></span>
         </button>
+        <script>
+          validClusters = <%= "#{OODClusters.map{|clust| clust.id.to_s}}".html_safe %>;
+          defaultCluster = 'all';
+        </script>
         <ul class="dropdown-menu">
           <% OODClusters.each do |cluster| %>
               <li class="cluster-dropdown-option" id="cluster-id-<%= cluster.id %>" onclick="set_cluster_id('<%= cluster.id %>');"><a href="#"><%= cluster.metadata.title || cluster.id.to_s.titleize %></a></li>


### PR DESCRIPTION
Fixes #170

There are two fixes here that probably shouldn't coexist. One prevents a 500 error from occuring in the JSON request and gives an error message that could mystify the user, but is more clear than before. The other is client-side, where the localStorage value is compared against the valid values, and the page is reloaded with 'all' clusters if the local value is invalid.

Also, kinda separate, but should `:cluster` be changed to `:jobcluster` [here](https://github.com/OSC/ood-activejobs/blob/master/app/controllers/pages_controller.rb#L15)?
