### PR TITLE
move performance tracking out of application.js

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -20,25 +20,13 @@
 //= require datatables_plugins/api/processing
 //= require_tree .
 
-// The app path without parameters
-var APP_PATH = window.location.pathname;
+function fetch_table_data(table, options){
+  if (!options) options = {};
+  if (!options.doneCallback) options.doneCallback = null;
+  if (!options.base_uri) options.base_uri = window.location.pathname;
 
-<% unless Rails.env.production? %>
-function report_performance(){
-  var marks = performance.getEntriesByType('mark');
-  marks.forEach(function(entry){
-    console.log(entry.startTime + "," + entry.name);
-  });
-
-  // hack but only one mark for document ready, and rest are draw times
-  console.log("version,documentReady,firstDraw,lastDraw");
-  console.log(`<%= `git describe --always --tags`.strip() %>,${marks[0].startTime},${marks[1].startTime},${marks.slice(-1)[0].startTime}`);
-}
-<% end %>
-
-function fetch_table_data(table){
   oboe({
-    url: APP_PATH + '/jobs.json?'+get_request_params(),
+    url: options.base_uri + '/jobs.json?'+get_request_params(),
     headers: {
       'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content'),
       'X-Requested-With': 'XMLHttpRequest'
@@ -51,13 +39,18 @@ function fetch_table_data(table){
   }).node('error.*', function(errors){
     show_errors(errors);
   }).done(function(){
-    <%= "setTimeout(report_performance, 2000);" unless Rails.env.production? %>
     table.processing(false);
+
+    if(options.doneCallback){
+       options.doneCallback();
+    }
   });
 }
 
-$(document).ready( function() {
-    <%= "performance.mark('document ready - build table and make ajax request for jobs');" unless Rails.env.production? %>
+function create_datatable(options){
+    if (!options) options = {};
+    if (!options.drawCallback) options.drawCallback = null;
+    if (!options.base_uri) options.base_uri = window.location.pathname;
 
     $("#selected-filter-label").text($("#filter-id-"+filter_id).text());
     $("#selected-cluster-label").text($("#cluster-id-"+cluster_id).text());
@@ -87,13 +80,11 @@ $(document).ready( function() {
                                         }
                                     },
         processing: true,           // Add the "processing" while json is being downloaded.
-        <% unless Rails.env.production? %>
         drawCallback: function(settings){
-          if(settings.aoData.length > 0){
-            performance.mark('draw records - ' + settings.aoData.length);
+          if(options.drawCallback){
+            options.drawCallback(settings);
           }
         },
-        <% end %>
         columns: [
             {
                 "orderable":        false,
@@ -192,7 +183,7 @@ $(document).ready( function() {
             // Open this row
             row.child( format(row.data()) ).show();
             tr.addClass('shown');
-            $.getJSON(APP_PATH + '/json?pbsid='+row.data().pbsid+'&cluster='+row.data().cluster , function(data) {
+            $.getJSON(options.base_uri + '/json?pbsid='+row.data().pbsid+'&cluster='+row.data().cluster , function(data) {
                 // Add the data panel to the view
                 $( "div[data-jobid='"+row.data().pbsid+"']").hide().html(data.html).fadeIn(250);
                 // Update the status label in the parent row
@@ -210,8 +201,8 @@ $(document).ready( function() {
 
     table.columns.adjust().draw();
 
-    fetch_table_data(table);
-});
+    return table;
+}
 
 
 

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -83,7 +83,7 @@ function has_ganglia(host) {
 
 var performance_tracking_enabled = false;
 
-<% unless Rails.env.production? %>
+<% if Configuration.console_log_performance_report? %>
 function report_performance(){
   var marks = performance.getEntriesByType('mark');
   marks.forEach(function(entry){

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -51,33 +51,72 @@
 </div>
 
 <script>
-    var filter_id = <%= (@jobfilter ? "'#{@jobfilter}'" : "localStorage.getItem('jobfilter') || '#{Filter.default_id}'").html_safe %>;
-    var cluster_id = <%= (@jobcluster ? "'#{@jobcluster}'" : "localStorage.getItem('jobcluster') || 'all'").html_safe %>;
+var filter_id = <%= (@jobfilter ? "'#{@jobfilter}'" : "localStorage.getItem('jobfilter') || '#{Filter.default_id}'").html_safe %>;
+var cluster_id = <%= (@jobcluster ? "'#{@jobcluster}'" : "localStorage.getItem('jobcluster') || 'all'").html_safe %>;
 
-    function build_ganglia_link( host, start_seconds, report_type, node_num, size ) {
-        var ganglia_uri;
-        <% OODClusters.each do |c| %>
-        if (host == '<%= c.id.to_s %>') {
-            <% if c.custom_allow?(:ganglia) %>
-              <% ganglia_cluster = OodCluster::Servers::Ganglia.new(c.custom_config(:ganglia)) %>
-              var ganglia_base = '<%= ganglia_cluster.uri.to_s %>';
-              ganglia_uri = ganglia_base+'&z='+size+'&cs='+start_seconds+'&g='+report_type+'&h=<%= (ganglia_cluster.opt_query.fetch(:h, '') % {h: '\'+node_num+\''}).html_safe %>';
-            <% else %>
-              ganglia_uri = '<%= image_path('unavailable.png') %>';
-            <% end %>
-        }
+function build_ganglia_link( host, start_seconds, report_type, node_num, size ) {
+    var ganglia_uri;
+    <% OODClusters.each do |c| %>
+    if (host == '<%= c.id.to_s %>') {
+        <% if c.custom_allow?(:ganglia) %>
+          <% ganglia_cluster = OodCluster::Servers::Ganglia.new(c.custom_config(:ganglia)) %>
+          var ganglia_base = '<%= ganglia_cluster.uri.to_s %>';
+          ganglia_uri = ganglia_base+'&z='+size+'&cs='+start_seconds+'&g='+report_type+'&h=<%= (ganglia_cluster.opt_query.fetch(:h, '') % {h: '\'+node_num+\''}).html_safe %>';
+        <% else %>
+          ganglia_uri = '<%= image_path('unavailable.png') %>';
         <% end %>
-        return ganglia_uri;
     }
+    <% end %>
+    return ganglia_uri;
+}
 
-    function has_ganglia(host) {
-        <% OODClusters.each do |c| %>
-        if (host == '<%= c.id.to_s %>') {
-            <% if c.custom_allow?(:ganglia) %>
-                return true;
-            <% end %>
-        }
+function has_ganglia(host) {
+    <% OODClusters.each do |c| %>
+    if (host == '<%= c.id.to_s %>') {
+        <% if c.custom_allow?(:ganglia) %>
+            return true;
         <% end %>
-        return false;
     }
+    <% end %>
+    return false;
+}
+
+var performance_tracking_enabled = false;
+
+<% unless Rails.env.production? %>
+function report_performance(){
+  var marks = performance.getEntriesByType('mark');
+  marks.forEach(function(entry){
+    console.log(entry.startTime + "," + entry.name);
+  });
+
+  // hack but only one mark for document ready, and rest are draw times
+  console.log("version,documentReady,firstDraw,lastDraw");
+  console.log(`<%= `git describe --always --tags`.strip() %>,${marks[0].startTime},${marks[1].startTime},${marks.slice(-1)[0].startTime}`);
+}
+
+performance_tracking_enabled = true;
+performance.mark('document ready - build table and make ajax request for jobs');
+<% end %>
+
+
+// FIXME: set options.base_uri
+var table = create_datatable({
+  drawCallback: function(settings){
+    // do a performance mark every time we draw the table (which happens when new records are downloaded)
+    if(performance_tracking_enabled && settings.aoData.length > 0){
+      performance.mark('draw records - ' + settings.aoData.length);
+    }
+  }
+});
+
+// FIXME: set options.base_uri
+fetch_table_data(table, {
+  doneCallback: function(){
+    // generate report after done fetching records
+    if(performance_tracking_enabled){
+      setTimeout(report_performance, 2000);
+    }
+  }
+});
 </script>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -99,24 +99,23 @@ performance_tracking_enabled = true;
 performance.mark('document ready - build table and make ajax request for jobs');
 <% end %>
 
-
-// FIXME: set options.base_uri
 var table = create_datatable({
   drawCallback: function(settings){
     // do a performance mark every time we draw the table (which happens when new records are downloaded)
     if(performance_tracking_enabled && settings.aoData.length > 0){
       performance.mark('draw records - ' + settings.aoData.length);
     }
-  }
+  },
+  base_uri: '<%= controller.relative_url_root %>'
 });
 
-// FIXME: set options.base_uri
 fetch_table_data(table, {
   doneCallback: function(){
     // generate report after done fetching records
     if(performance_tracking_enabled){
       setTimeout(report_performance, 2000);
     }
-  }
+  },
+  base_uri: '<%= controller.relative_url_root %>'
 });
 </script>

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -73,6 +73,10 @@ class ConfigurationSingleton
     Pathname.new(root).expand_path
   end
 
+  def console_log_performance_report?
+    dataroot.join("debug").file? || rails_env != 'production'
+  end
+
   private
 
   # The environment


### PR DESCRIPTION
document ready is no longer used; now application.js just contains functions that must be called
APP_PATH is now set via options.base_uri argument
performance tracking is enabled and managed by passing in code via the index view in script tag